### PR TITLE
Add pragma comment for ecrecover safety

### DIFF
--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -1,4 +1,7 @@
+// Update this to `pragma solidity 0.4.14` as early as possible to account for ecrecover bugfix
+// This is currently blocked by truffle not yet supporting 0.4.14 https://github.com/trufflesuite/truffle/releases
 pragma solidity 0.4.11;
+
 contract SimpleMultiSig {
 
   uint public nonce;                // (only) mutable state


### PR DESCRIPTION
Related to #2. I haven't assessed how vulnerable the simple-multisig might be to this, but this comments seems like a reasonable safety measure.