### PR TITLE
Update to 0.4.15

### DIFF
--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.11;
+pragma solidity 0.4.15;
 contract SimpleMultiSig {
 
   uint public nonce;                // (only) mutable state


### PR DESCRIPTION
Truffle doesn't support this yet, but it should very, very soon. So this should be merged in ASAP after truffle 3.4.9 is out to prevent any unwanted issues with `ecrecover`