### PR TITLE
keccak256 (over sha3)

### DIFF
--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -25,7 +25,7 @@ contract SimpleMultiSig {
     require(sigR.length == sigS.length && sigR.length == sigV.length);
 
     // Follows ERC191 signature scheme: https://github.com/ethereum/EIPs/issues/191
-    bytes32 txHash = sha3(byte(0x19), byte(0), this, destination, value, data, nonce);
+    bytes32 txHash = keccak256(byte(0x19), byte(0), this, destination, value, data, nonce);
 
     address lastAdd = address(0); // cannot have address(0) as an owner
     for (uint i = 0; i < threshold; i++) {


### PR DESCRIPTION
keccak256 is pretty much now in all Ethereum docs, including Solidity and the Yellow Paper