### PR TITLE
Use assembly instead of addr.call()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes #
 
+## Version 1.0.2 - 2018-05-04 ##
+
+* Updated to use assembly instead of `address.call()` syntax. Thanks to [ethers](https://github.com/ethers) for the suggestion. For more info about the problems with `address.call()` see [here](https://github.com/ethereum/solidity/issues/2884).
+
+* Fix indentation mismatch.
+
 ## Version 1.0.1 - 2018-05-04 ##
 
 * Update to work with latest Solidity and Truffle version. By [grempe](https://github.com/grempe)

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -30,14 +30,22 @@ contract SimpleMultiSig {
 
     address lastAdd = address(0); // cannot have address(0) as an owner
     for (uint i = 0; i < threshold; i++) {
-        address recovered = ecrecover(txHash, sigV[i], sigR[i], sigS[i]);
-        require(recovered > lastAdd && isOwner[recovered]);
-        lastAdd = recovered;
+      address recovered = ecrecover(txHash, sigV[i], sigR[i], sigS[i]);
+      require(recovered > lastAdd && isOwner[recovered]);
+      lastAdd = recovered;
     }
 
     // If we make it here all signatures are accounted for
     nonce = nonce + 1;
-    require(destination.call.value(value)(data));
+    require(executeCall(destination, value, data));
+  }
+
+  // The address.call() syntax is no longer recommended, see:
+  // https://github.com/ethereum/solidity/issues/2884
+  function executeCall(address to, uint256 value, bytes data) internal returns (bool success) {
+    assembly {
+      success := call(gas, to, value, add(data, 0x20), mload(data), 0, 0)
+    }
   }
 
   function () payable public {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-multisig",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple Ethereum multisig contract",
   "main": "test/simplemultisig.js",
   "directories": {


### PR DESCRIPTION
Updated to use assembly in Solidity rather than the `address.call()` construct which is [problematic](https://github.com/ethereum/solidity/issues/2884).