### PR TITLE
Check that threshold is positive instead of non-zero

### DIFF
--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -8,7 +8,7 @@ contract SimpleMultiSig {
   address[] public ownersArr;        // immutable state
 
   function SimpleMultiSig(uint threshold_, address[] owners_) public {
-    require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ != 0);
+    require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ >= 0);
 
     address lastAdd = address(0); 
     for (uint i = 0; i < owners_.length; i++) {


### PR DESCRIPTION
This is semantically equivalent because threadshold is unsigned, so this proposed change should have zero effect on the code.

However, I believe that it is slightly more legible/simple this way. Reasoning about `threshold_ <= owners_.length && threshold_ >= 0` is easier than reasoning about `threshold_ <= owners_.length && threshold_ != 0` because you don't have to think about threshold's type. The semantic we are trying to check is is that threashold is within the range `[0, owners_.length)`, and I believe my suggestion captures this semantic slightly better.