### PR TITLE
Move assembly to execute function

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes #
 
+## Version 1.0.3 - 2018-06-11 ##
+
+* Moved the assembly to inside the `execute()` function and removed the `executeCall()` function. This is to avoid the possibility of the `internal` keyword on the `executeCall()` function being accidentally removed which would have catastrophic consequences.
+
 ## Version 1.0.2 - 2018-05-04 ##
 
 * Updated to use assembly instead of `address.call()` syntax. Thanks to [ethers](https://github.com/ethers) for the suggestion. For more info about the problems with `address.call()` see [here](https://github.com/ethereum/solidity/issues/2884).

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -35,17 +35,13 @@ contract SimpleMultiSig {
       lastAdd = recovered;
     }
 
-    // If we make it here all signatures are accounted for
+    // If we make it here all signatures are accounted for.
+    // The address.call() syntax is no longer recommended, see:
+    // https://github.com/ethereum/solidity/issues/2884
     nonce = nonce + 1;
-    require(executeCall(destination, value, data));
-  }
-
-  // The address.call() syntax is no longer recommended, see:
-  // https://github.com/ethereum/solidity/issues/2884
-  function executeCall(address to, uint256 value, bytes data) internal returns (bool success) {
-    assembly {
-      success := call(gas, to, value, add(data, 0x20), mload(data), 0, 0)
-    }
+    bool success = false;
+    assembly { success := call(gas, destination, value, add(data, 0x20), mload(data), 0, 0) }
+    require(success);
   }
 
   function () payable public {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-multisig",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Simple Ethereum multisig contract",
   "main": "test/simplemultisig.js",
   "directories": {


### PR DESCRIPTION
Move assembly to `execute` and deleted `executeCall` function to eliminate the possibility that an `internal` keyword is accidentally removed which would be catastrophic.