### PR TITLE
Nonce window

### DIFF
--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -52,6 +52,7 @@ contract SimpleMultiSig {
   function execute_with_nonce_index(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data, uint nonce_index) public {
     require(sigR.length == threshold);
     require(sigR.length == sigS.length && sigR.length == sigV.length);
+    require(nonce_index < nonces.length);
 
     // Follows ERC191 signature scheme: https://github.com/ethereum/EIPs/issues/191
     bytes32 txHash = keccak256(byte(0x19), byte(0), this, destination, value, data, nonces[nonce_index]);

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -13,6 +13,7 @@ contract SimpleMultiSig {
   constructor(uint threshold_, address[] owners_, uint nonce_window_size) public {
     require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ >= 0 && nonce_window_size > 0);
     admin = msg.sender;
+    next_nonce = 0;
 
     address lastAdd = address(0); 
     for (uint i = 0; i < owners_.length; i++) {
@@ -35,8 +36,8 @@ contract SimpleMultiSig {
   }
 
   // Use up the nonce at the specified index, aborting any in-flight transactionwith that nonce
-  function cancel(uint nonce_index) public {
-    require(msg.sender == admin);
+  function cancel_nonce(uint nonce_index) public {
+    require(msg.sender == admin && nonce_index < nonces.length);
 
     nonces[nonce_index] = next_nonce++;
   }

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -42,13 +42,13 @@ contract SimpleMultiSig {
   }
 
   // Execute with first nonce.
-  // If you want to perform concurrent requests, use execute_at_nonce.
+  // If you want to perform concurrent requests, use execute_with_nonce_index.
   function execute(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data) public {
-      execute_at_nonce(sigV, sigR, sigS, destination, value, data, 0);
+      execute_with_nonce_index(sigV, sigR, sigS, destination, value, data, 0);
   }
 
   // Note that address recovered from signatures must be strictly increasing, in order to prevent duplicates
-  function execute_at_nonce(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data, uint nonce_index) public {
+  function execute_with_nonce_index(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data, uint nonce_index) public {
     require(sigR.length == threshold);
     require(sigR.length == sigS.length && sigR.length == sigV.length);
 

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -2,14 +2,17 @@ pragma solidity ^0.4.22;
 
 contract SimpleMultiSig {
 
-  uint public nonce;                 // (only) mutable state
+  uint[] public nonces;              // mutable state
+  uint public next_nonce;            // mutable state
   uint public threshold;             // immutable state
   mapping (address => bool) isOwner; // immutable state
   address[] public ownersArr;        // immutable state
+  address admin;                     // immutable state
 
   // Note that owners_ must be strictly increasing, in order to prevent duplicates
-  constructor(uint threshold_, address[] owners_) public {
-    require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ >= 0);
+  constructor(uint threshold_, address[] owners_, uint nonce_window_size) public {
+    require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ >= 0 && nonce_window_size > 0);
+    admin = msg.sender;
 
     address lastAdd = address(0); 
     for (uint i = 0; i < owners_.length; i++) {
@@ -19,15 +22,38 @@ contract SimpleMultiSig {
     }
     ownersArr = owners_;
     threshold = threshold_;
+    nonces.length = nonce_window_size;
+    for (uint j = 0; j < nonces.length; j++) {
+        nonces[j] = next_nonce++;
+    }
+  }
+
+  // Return the first available nonce.
+  // If you want to perform concurrent requests, access the nonces array directly.
+  function nonce() view public returns (uint) {
+    return nonces[0];
+  }
+
+  // Use up the nonce at the specified index, aborting any in-flight transactionwith that nonce
+  function cancel(uint nonce_index) public {
+    require(msg.sender == admin);
+
+    nonces[nonce_index] = next_nonce++;
+  }
+
+  // Execute with first nonce.
+  // If you want to perform concurrent requests, use execute_at_nonce.
+  function execute(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data) public {
+      execute_at_nonce(sigV, sigR, sigS, destination, value, data, 0);
   }
 
   // Note that address recovered from signatures must be strictly increasing, in order to prevent duplicates
-  function execute(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data) public {
+  function execute_at_nonce(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data, uint nonce_index) public {
     require(sigR.length == threshold);
     require(sigR.length == sigS.length && sigR.length == sigV.length);
 
     // Follows ERC191 signature scheme: https://github.com/ethereum/EIPs/issues/191
-    bytes32 txHash = keccak256(byte(0x19), byte(0), this, destination, value, data, nonce);
+    bytes32 txHash = keccak256(byte(0x19), byte(0), this, destination, value, data, nonces[nonce_index]);
 
     address lastAdd = address(0); // cannot have address(0) as an owner
     for (uint i = 0; i < threshold; i++) {
@@ -39,7 +65,7 @@ contract SimpleMultiSig {
     // If we make it here all signatures are accounted for.
     // The address.call() syntax is no longer recommended, see:
     // https://github.com/ethereum/solidity/issues/2884
-    nonce = nonce + 1;
+    nonces[nonce_index] = next_nonce++;
     bool success = false;
     assembly { success := call(gas, destination, value, add(data, 0x20), mload(data), 0, 0) }
     require(success);

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -37,7 +37,7 @@ contract('SimpleMultiSig', function(accounts) {
 
   let executeSendSuccess = async function(owners, threshold, signers, done) {
 
-    let multisig = await SimpleMultiSig.new(threshold, owners, {from: accounts[0]})
+    let multisig = await SimpleMultiSig.new(threshold, owners, 1, {from: accounts[0]})
 
     let randomAddr = solsha3(Math.random()).slice(0,42)
 
@@ -108,7 +108,7 @@ contract('SimpleMultiSig', function(accounts) {
 
   let executeSendFailure = async function(owners, threshold, signers, done) {
 
-    let multisig = await SimpleMultiSig.new(threshold, owners, {from: accounts[0]})
+    let multisig = await SimpleMultiSig.new(threshold, owners, 1, {from: accounts[0]})
 
     let nonce = await multisig.nonce.call()
     assert.equal(nonce.toNumber(), 0)
@@ -136,7 +136,7 @@ contract('SimpleMultiSig', function(accounts) {
   let creationFailure = async function(owners, threshold, done) {
 
     try {
-      await SimpleMultiSig.new(threshold, owners, {from: accounts[0]})
+      await SimpleMultiSig.new(threshold, owners, 1, {from: accounts[0]})
     }
     catch(error) {
       errMsg = error.message

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -116,9 +116,9 @@ contract('SimpleMultiSig', function(accounts) {
     // Receive funds
     await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(new BigNumber(0.1), 'ether')})
 
-    let nonce0 = await multisig.nonces.call(0)
+    let nonce0 = await multisig.noncesArr.call(0)
     assert.equal(nonce0.toNumber(), 0)
-    let nonce1 = await multisig.nonces.call(1)
+    let nonce1 = await multisig.noncesArr.call(1)
     assert.equal(nonce1.toNumber(), 1)
 
     let bal = await web3GetBalance(multisig.address)
@@ -148,8 +148,8 @@ contract('SimpleMultiSig', function(accounts) {
     assert.equal(bal.toString(), value.toString())
 
     // Check nonce updated
-    assert.equal((await multisig.nonces.call(0)).toNumber(), 3)
-    assert.equal((await multisig.nonces.call(1)).toNumber(), 2)
+    assert.equal((await multisig.noncesArr.call(0)).toNumber(), 3)
+    assert.equal((await multisig.noncesArr.call(1)).toNumber(), 2)
 
     done()
   }
@@ -163,7 +163,7 @@ contract('SimpleMultiSig', function(accounts) {
     // Receive funds
     await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(new BigNumber(0.1), 'ether')})
 
-    let nonce0 = await multisig.nonces.call(0)
+    let nonce0 = await multisig.noncesArr.call(0)
     assert.equal(nonce0.toNumber(), 0)
 
     let bal = await web3GetBalance(multisig.address)
@@ -171,7 +171,7 @@ contract('SimpleMultiSig', function(accounts) {
 
     await multisig.cancel_nonce(0)
 
-    assert.equal((await multisig.nonces.call(0)).toNumber(), 2)
+    assert.equal((await multisig.noncesArr.call(0)).toNumber(), 2)
 
     let value = web3.toWei(new BigNumber(0.01), 'ether')
 
@@ -215,7 +215,7 @@ contract('SimpleMultiSig', function(accounts) {
 
     let errMsg1 = ''
     try {
-        await multisig.nonces.call(2)
+        await multisig.noncesArr.call(2)
     }
     catch(error) {
       errMsg1 = error.message


### PR DESCRIPTION
## Motivation

Multi-sig transactions are likely to take longer to finalize, because of the need to collect signatures from multiple parties.  For higher security setups that include offline keys, this may be hours or days.  When a transaction is pending, it is difficult to start the workflow for a second transaction, because we don't know what nonce to use.  Optimistically it should be the next value, but if the current transaction is rejected, that value would not be useful since nonces must be consumed in strict sequence.

## Description

This PR converts the scalar state `nonce` into the state array `noncesArr`.  Multiple transactions can use different slots in this array.  A pending transaction can be aborted by use of `cancel_nonce()` and the slot freed up for further use.
