### PR TITLE
Ensure correct usage of BigNumber

### DIFF
--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -4,7 +4,6 @@ var lightwallet = require('eth-lightwallet')
 const solsha3 = require('solidity-sha3').default
 const leftPad = require('left-pad')
 const Promise = require('bluebird')
-const BigNumber = require('bignumber.js')
 
 const web3SendTransaction = Promise.promisify(web3.eth.sendTransaction)
 const web3GetBalance = Promise.promisify(web3.eth.getBalance)

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -42,7 +42,7 @@ contract('SimpleMultiSig', function(accounts) {
     let randomAddr = solsha3(Math.random()).slice(0,42)
 
     // Receive funds
-    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(new BigNumber(0.1), 'ether')})
+    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(web3.toBigNumber(0.1), 'ether')})
 
     let nonce = await multisig.nonce.call()
     assert.equal(nonce.toNumber(), 0)
@@ -56,7 +56,7 @@ contract('SimpleMultiSig', function(accounts) {
       assert.equal(owners[i], ownerFromContract)
     }
 
-    let value = web3.toWei(new BigNumber(0.01), 'ether')
+    let value = web3.toWei(web3.toBigNumber(0.01), 'ether')
 
     let sigs = createSigs(signers, multisig.address, nonce, randomAddr, value, '0x')
 
@@ -114,10 +114,10 @@ contract('SimpleMultiSig', function(accounts) {
     assert.equal(nonce.toNumber(), 0)
 
     // Receive funds
-    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(new BigNumber(2), 'ether')})
+    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(web3.toBigNumber(2), 'ether')})
 
     let randomAddr = solsha3(Math.random()).slice(0,42)
-    let value = web3.toWei(new BigNumber(0.1), 'ether')
+    let value = web3.toWei(web3.toBigNumber(0.1), 'ether')
     let sigs = createSigs(signers, multisig.address, nonce, randomAddr, value, '0x')
 
     let errMsg = ''


### PR DESCRIPTION
Applying the issue described at https://github.com/christianlundkvist/simple-multisig/issues/33:
Replaced each occurrence of `new BigNumber` with `web3.toBigNumber`, in order to ensure that compatible `BigNumber` instances are passed to `Web3` functions.