### PR TITLE
EIP712 support and adding data to be signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
 # simple-multisig
-Simple multisig for Ethereum using detached signatures
+
+## Introduction
 
 This is an Ethereum multisig contract designed to be as simple as possible. It is described further in this [medium post](https://medium.com/@ChrisLundkvist/exploring-simpler-ethereum-multisig-contracts-b71020c19037).
 
 The main idea behind the contract is to pass in a threshold of detached signatures into the `execute` function and the contract will check the signatures and send off the transaction.
 
 For a review by maurelian, see the file `maurelian_review.md`.
+
+## Version 2.0.0 Update to EIP712
+
+In version 2.0.0 the Simple Multisig was updated to use the EIP712 signature standard. This means that the signature format of the previous version is no longer compatible. If your contract is already deployed and in use it still works but that version will no longer be supported in the future. We recommend moving ETH and tokens over to a newly deployed contract and using the EIP712 format going forward.
+
+## Data to be signed
+
+The Simple MultiSig uses the [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) standard to package and hash the data to be signed. Each signer will sign a message over the following data fields, which encode the ethereum transaction to execute:
+
+* `address destination` - The target address for the transaction
+* `uint256 value` - The value of the transaction expressed in Wei
+* `bytes data` - The data of the transaction in hex format
+* `uint256 nonce` - The nonce for this transaction. Must match the current nonce in the multisig contract.
+* `address executor` - Specifies which Ethereum address is allowed to call the `execute` function. It is allowed to specify the zero address as an executor, in which case any address can call the `execute` function. This field is mainly to address concerns about replay attacks in some edge cases.
+* `uint256 gasLimit` - Specifies how much gas to pass on to the final `call`, independently of how much gas is supplied to the transaction calling the `execute` function. This can be used to constrain what kind of computations can be performed by the target smart contract. If the signers do not need this level of control a very high gasLimit of several million can be used for this data field.
+
+The data to be signed also includes the following EIP712 Domain data that specifies the context of the signed data:
+
+* Name (`"Simple MultiSig"`)
+* Version (`"1"`)
+* ChainId (Integer marking current chain, e.g. 1 for mainnet)
+* Contract Address (Address of the specific multisig contract instance)
+* Salt (`0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf758dc33cc0`, unique identifier specific to SimpleMultisig)
+
+## Installation and testing
 
 Install global dependencies:
 
@@ -17,3 +43,7 @@ To run the tests:
 * Make sure `ganache-cli` is running in its own terminal window.
 * `npm install`
 * `npm run test`
+
+## Testing signatures in a browser
+
+If you have the [MetaMask](https://metamask.io) browser extension you can open the page `browsertest/index.html` in your browser and test signing data. The signature will be returned in a `(r,s,v)` format which can be plugged into the `execute` function.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a review by maurelian, see the file `maurelian_review.md`.
 
 ## Version 2.0.0 Update to EIP712
 
-In version 2.0.0 the Simple Multisig was updated to use the EIP712 signature standard. This means that the signature format of the previous version is no longer compatible. If your contract is already deployed and in use it still works but that version will no longer be supported in the future. We recommend moving ETH and tokens over to a newly deployed contract and using the EIP712 format going forward.
+In version 2.0.0 the Simple Multisig was updated to use the EIP712 signature standard. This means that the signature format of the previous version is no longer compatible. If your contract is already deployed and in use it still works but that version will no longer be supported in the future. We recommend moving ETH and tokens over to a newly deployed contract and using the EIP712 format going forward. Another change to be aware of is that the constructor now takes an extra parameter `chainId` to specify which network the contract is deployed on.
 
 ## Data to be signed
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,8 @@
 
 * Add `gasLimit` to the signed data in order to specify how much gas to supply to the function call.
 
+* Add input parameter `chainId` to the constructor.
+
 * Change fallback function from `public` to `external`.
 
 * Update tests for EIP712.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,8 @@
 
 * Update Solidity compiler version to 0.4.24.
 
+* Remove use of `bignumber.js` and replace with `web3.toBigNumber()` (Thanks to [barakman](https://github.com/barakman)).
+
 ## Version 1.0.4 - 2018-06-12 ##
 
 * Document owners_ address being strictly increasing, by [ripper234](https://github.com/ripper234)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,8 @@
 
 * Add test for wrong nonce.
 
+* Update Solidity compiler version to 0.4.24.
+
 ## Version 1.0.4 - 2018-06-12 ##
 
 * Document owners_ address being strictly increasing, by [ripper234](https://github.com/ripper234)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes #
 
+## Version 2.0.0 - 2018-08-18 ##
+
+* Backwards incompatible update of main contract to support [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
+
+* Add `executor` to the signed data in order to specify which address needs to call the `execute` function. Allows `address(0)` as valid executor if the signers want anyone to be able to execute the transaction.
+
+* Add `gasLimit` to the signed data in order to specify how much gas to supply to the function call.
+
+* Change fallback function from `public` to `external`.
+
+* Update tests for EIP712.
+
+* Add test for wrong nonce.
+
 ## Version 1.0.4 - 2018-06-12 ##
 
 * Document owners_ address being strictly increasing, by [ripper234](https://github.com/ripper234)

--- a/browsertest/index.html
+++ b/browsertest/index.html
@@ -1,0 +1,53 @@
+<head>
+  <meta charset="utf-8">
+  <title>EIP712 browser demo</title>
+</head>
+<body>
+  <script src="./sign.js" language="javascript"></script>
+  <p>
+    This page tests signing a SimpleMultiSig transaction using EIP712. It is based on <a href="https://weijiekoh.github.io/eip712-signing-demo/index.html">this EIP712 demo</a> by Wei Jie Koh.
+  </p>
+
+  <table>
+    <thead>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Wallet address</td>
+        <td><input type="text" id="walletAddress" size="40" value="0xe3de7de481cbde9b4d5f62c6d228ec62277560c8"></td>
+      </tr>
+      <tr>
+        <td>Destination</td>
+        <td><input type="text" id="destination" size="40" value="0x8582afea2dd8e47297dbcdcf9ca289756ee21430"></td>
+      </tr>
+      <tr>
+        <td>Value</td>
+        <td><input type="text" id="value" size="10" value="10000000000000000"></td>
+      </tr>
+      <tr>
+        <td>Data</td>
+        <td><input type="text" id="data" size="40" value="0xf207564e0000000000000000000000000000000000000000000000000000000000003039"></td>
+      </tr>
+      <tr>
+        <td>Nonce</td>
+        <td><input type="text" id="nonce" size="10" value="2"/></td>
+      </tr>
+      <tr>
+        <td>Executor</td>
+        <td><input type="text" id="executor" size="40" value="0x0be430662ec0659ee786c04925c0146991fbdc0f"></td>
+      </tr>
+      <tr>
+        <td>GasLimit</td>
+        <td><input type="text" id="gasLimit" size="10" value="100000"></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <button id="signBtn">Sign data</button>
+  
+  <h3>Signed Data</h3>
+  <div><textarea id='signedData' rows=8 cols=40></textarea></div>
+  
+
+</body>
+  

--- a/browsertest/sign.js
+++ b/browsertest/sign.js
@@ -1,0 +1,91 @@
+function parseSignature(signature) {
+  var r = signature.substring(0, 64);
+  var s = signature.substring(64, 128);
+  var v = signature.substring(128, 130);
+
+  return {
+      r: "0x" + r,
+      s: "0x" + s,
+      v: parseInt(v, 16)
+  }
+}
+
+window.onload = function (e) {
+
+  // force the user to unlock their MetaMask
+  if (web3.eth.accounts[0] == null) {
+    alert("Please unlock MetaMask first");
+  }
+
+  var signBtn = document.getElementById("signBtn");
+  signBtn.onclick = function(e) {
+    if (web3.eth.accounts[0] == null) {
+      return;
+    }
+
+    const domain = [
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+      { name: "salt", type: "bytes32" }
+    ];
+
+    const multiSigTx = [
+      { name: "destination", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "data", type: "bytes" },
+      { name: "nonce", type: "uint256" },
+      { name: "executor", type: "address" },
+      { name: "gasLimit", type: "uint256" }
+    ];
+
+    const domainData = {
+      name: "Simple MultiSig",
+      version: "1",
+      chainId: parseInt(web3.version.network, 10),
+      verifyingContract: document.getElementById("walletAddress").value,
+      salt: "0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf758dc33cc0"
+    };
+
+    var message = {
+      destination: document.getElementById("destination").value,
+      value: document.getElementById("value").value,
+      data: document.getElementById("data").value,
+      nonce: parseInt(document.getElementById("nonce").value, 10),
+      executor: document.getElementById("executor").value,
+      gasLimit: parseInt(document.getElementById("gasLimit").value, 10),
+    };
+    
+    const data = JSON.stringify({
+      types: {
+        EIP712Domain: domain,
+        MultiSigTransaction: multiSigTx
+      },
+      domain: domainData,
+      primaryType: "MultiSigTransaction",
+      message: message
+    });
+
+    console.log(data)
+    
+    const signer = web3.eth.accounts[0];
+
+    console.log(signer)
+    web3.currentProvider.sendAsync(
+      {
+        method: "eth_signTypedData_v3",
+        params: [signer, data],
+        from: signer
+      }, 
+      function(err, result) {
+        if (err || result.error) {
+          return console.error(result);
+        }
+
+        const signature = parseSignature(result.result.substring(2));
+        document.getElementById("signedData").value = "r: " + signature.r + "\ns: " + signature.s + "\nv: " + signature.v
+      }
+    );
+  };
+}

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -14,7 +14,9 @@ bytes32 constant VERSION_HASH = 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307
 
 // kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce,address executor,uint256 gasLimit)")
 bytes32 constant TXTYPE_HASH = 0x3ee892349ae4bbe61dce18f95115b5dc02daf49204cc602458cd4c1f540d56d7;
-  
+
+bytes32 constant SALT = 0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf758dc33cc0;
+
   uint public nonce;                 // (only) mutable state
   uint public threshold;             // immutable state
   mapping (address => bool) isOwner; // immutable state
@@ -39,7 +41,8 @@ bytes32 constant TXTYPE_HASH = 0x3ee892349ae4bbe61dce18f95115b5dc02daf49204cc602
                                             NAME_HASH,
                                             VERSION_HASH,
                                             chainId,
-                                            this));
+                                            this,
+                                            SALT));
   }
 
   // Note that address recovered from signatures must be strictly increasing, in order to prevent duplicates

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -12,21 +12,21 @@ bytes32 constant NAME_HASH = 0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7
 // kekkac256("1")
 bytes32 constant VERSION_HASH = 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6;
 
-// kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce)")
-bytes32 constant TXTYPE_HASH = 0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b;
+// kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce,address executor,uint256 gasLimit)")
+bytes32 constant TXTYPE_HASH = 0x3ee892349ae4bbe61dce18f95115b5dc02daf49204cc602458cd4c1f540d56d7;
   
   uint public nonce;                 // (only) mutable state
   uint public threshold;             // immutable state
   mapping (address => bool) isOwner; // immutable state
   address[] public ownersArr;        // immutable state
 
-  bytes32 DOMAIN_SEPARATOR;
+  bytes32 DOMAIN_SEPARATOR;          // hash for EIP712, computed from contract address
   
   // Note that owners_ must be strictly increasing, in order to prevent duplicates
   constructor(uint threshold_, address[] owners_, uint chainId) public {
     require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ > 0);
 
-    address lastAdd = address(0); 
+    address lastAdd = address(0);
     for (uint i = 0; i < owners_.length; i++) {
       require(owners_[i] > lastAdd);
       isOwner[owners_[i]] = true;
@@ -43,12 +43,13 @@ bytes32 constant TXTYPE_HASH = 0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687
   }
 
   // Note that address recovered from signatures must be strictly increasing, in order to prevent duplicates
-  function execute(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data) public {
+  function execute(uint8[] sigV, bytes32[] sigR, bytes32[] sigS, address destination, uint value, bytes data, address executor, uint gasLimit) public {
     require(sigR.length == threshold);
     require(sigR.length == sigS.length && sigR.length == sigV.length);
+    require(executor == msg.sender || executor == address(0));
 
     // EIP712 scheme: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md
-    bytes32 txInputHash = keccak256(abi.encode(TXTYPE_HASH, destination, value, keccak256(data), nonce));
+    bytes32 txInputHash = keccak256(abi.encode(TXTYPE_HASH, destination, value, keccak256(data), nonce, executor, gasLimit));
     bytes32 totalHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, txInputHash));
 
     address lastAdd = address(0); // cannot have address(0) as an owner
@@ -63,7 +64,7 @@ bytes32 constant TXTYPE_HASH = 0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687
     // https://github.com/ethereum/solidity/issues/2884
     nonce = nonce + 1;
     bool success = false;
-    assembly { success := call(gas, destination, value, add(data, 0x20), mload(data), 0, 0) }
+    assembly { success := call(gasLimit, destination, value, add(data, 0x20), mload(data), 0, 0) }
     require(success);
   }
 

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -1,21 +1,20 @@
 pragma solidity ^0.4.22;
 
-// EIP712 Precomputed hashes:
-//
-// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)") =
-// 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f
-//
-// kekkac256("Simple MultiSig") = 
-// 0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6
-//
-// kekkac256("1") = 
-// 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6
-//
-// kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce)") =
-// 0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b
-
 contract SimpleMultiSig {
 
+// EIP712 Precomputed hashes:
+// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+bytes32 constant EIP712DOMAINTYPE_HASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+// kekkac256("Simple MultiSig")
+bytes32 constant NAME_HASH = 0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6;
+
+// kekkac256("1")
+bytes32 constant VERSION_HASH = 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6;
+
+// kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce)")
+bytes32 constant TXTYPE_HASH = 0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b;
+  
   uint public nonce;                 // (only) mutable state
   uint public threshold;             // immutable state
   mapping (address => bool) isOwner; // immutable state
@@ -36,9 +35,9 @@ contract SimpleMultiSig {
     ownersArr = owners_;
     threshold = threshold_;
 
-    DOMAIN_SEPARATOR = keccak256(abi.encode(0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f,
-                                            0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6,
-                                            0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6,
+    DOMAIN_SEPARATOR = keccak256(abi.encode(EIP712DOMAINTYPE_HASH,
+                                            NAME_HASH,
+                                            VERSION_HASH,
                                             chainId,
                                             this));
   }
@@ -49,7 +48,7 @@ contract SimpleMultiSig {
     require(sigR.length == sigS.length && sigR.length == sigV.length);
 
     // EIP712 scheme: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md
-    bytes32 txInputHash = keccak256(abi.encode(0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b, destination, value, keccak256(data), nonce));
+    bytes32 txInputHash = keccak256(abi.encode(TXTYPE_HASH, destination, value, keccak256(data), nonce));
     bytes32 totalHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, txInputHash));
 
     address lastAdd = address(0); // cannot have address(0) as an owner

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -7,9 +7,11 @@ contract SimpleMultiSig {
   mapping (address => bool) isOwner; // immutable state
   address[] public ownersArr;        // immutable state
 
+  bytes32 DOMAIN_SEPARATOR;
+  
   // Note that owners_ must be strictly increasing, in order to prevent duplicates
   constructor(uint threshold_, address[] owners_) public {
-    require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ >= 0);
+    require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ > 0);
 
     address lastAdd = address(0); 
     for (uint i = 0; i < owners_.length; i++) {
@@ -19,6 +21,14 @@ contract SimpleMultiSig {
     }
     ownersArr = owners_;
     threshold = threshold_;
+
+    // DOMAIN_SEPARATOR = keccak256(abi.encode(EIP712_HASH,
+    //                                         NAME_HASH,
+    //                                         VERSION_HASH,
+    //                                         chainId,
+    //                                         this));
+
+    DOMAIN_SEPARATOR = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
   }
 
   // Note that address recovered from signatures must be strictly increasing, in order to prevent duplicates
@@ -26,12 +36,13 @@ contract SimpleMultiSig {
     require(sigR.length == threshold);
     require(sigR.length == sigS.length && sigR.length == sigV.length);
 
-    // Follows ERC191 signature scheme: https://github.com/ethereum/EIPs/issues/191
-    bytes32 txHash = keccak256(byte(0x19), byte(0), this, destination, value, data, nonce);
+    // EIP712 scheme: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md
+    bytes32 txInputHash = keccak256(abi.encode(0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b, destination, value, keccak256(data), nonce));
+    bytes32 totalHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, txInputHash));
 
     address lastAdd = address(0); // cannot have address(0) as an owner
     for (uint i = 0; i < threshold; i++) {
-      address recovered = ecrecover(txHash, sigV[i], sigR[i], sigS[i]);
+      address recovered = ecrecover(totalHash, sigV[i], sigR[i], sigS[i]);
       require(recovered > lastAdd && isOwner[recovered]);
       lastAdd = recovered;
     }

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -1,5 +1,19 @@
 pragma solidity ^0.4.22;
 
+// EIP712 Precomputed hashes:
+//
+// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)") =
+// 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f
+//
+// kekkac256("Simple MultiSig") = 
+// 0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6
+//
+// kekkac256("1") = 
+// 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6
+//
+// kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce)") =
+// 0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b
+
 contract SimpleMultiSig {
 
   uint public nonce;                 // (only) mutable state
@@ -10,7 +24,7 @@ contract SimpleMultiSig {
   bytes32 DOMAIN_SEPARATOR;
   
   // Note that owners_ must be strictly increasing, in order to prevent duplicates
-  constructor(uint threshold_, address[] owners_) public {
+  constructor(uint threshold_, address[] owners_, uint chainId) public {
     require(owners_.length <= 10 && threshold_ <= owners_.length && threshold_ > 0);
 
     address lastAdd = address(0); 
@@ -22,13 +36,11 @@ contract SimpleMultiSig {
     ownersArr = owners_;
     threshold = threshold_;
 
-    // DOMAIN_SEPARATOR = keccak256(abi.encode(EIP712_HASH,
-    //                                         NAME_HASH,
-    //                                         VERSION_HASH,
-    //                                         chainId,
-    //                                         this));
-
-    DOMAIN_SEPARATOR = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+    DOMAIN_SEPARATOR = keccak256(abi.encode(0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f,
+                                            0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6,
+                                            0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6,
+                                            chainId,
+                                            this));
   }
 
   // Note that address recovered from signatures must be strictly increasing, in order to prevent duplicates

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -71,5 +71,5 @@ bytes32 constant SALT = 0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf
     require(success);
   }
 
-  function () payable public {}
+  function () payable external {}
 }

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.22;
+pragma solidity ^0.4.24;
 
 contract SimpleMultiSig {
 

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.4.22;
 contract SimpleMultiSig {
 
 // EIP712 Precomputed hashes:
-// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
-bytes32 constant EIP712DOMAINTYPE_HASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)")
+bytes32 constant EIP712DOMAINTYPE_HASH = 0xd87cd6ef79d4e2b95e15ce8abf732db51ec771f1ca2edccf22a46c729ac56472;
 
 // kekkac256("Simple MultiSig")
 bytes32 constant NAME_HASH = 0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6;

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   "homepage": "https://github.com/christianlundkvist/simple-multisig#readme",
   "devDependencies": {
     "eth-lightwallet": "*",
-    "bluebird": "*",
-    "left-pad": "*",
-    "solidity-sha3": "*"
+    "bluebird": "*"
   }
 }

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -12,6 +12,8 @@ const TXTYPE_HASH = '0x3ee892349ae4bbe61dce18f95115b5dc02daf49204cc602458cd4c1f5
 const NAME_HASH = '0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6'
 const VERSION_HASH = '0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6'
 const EIP712DOMAINTYPE_HASH = '0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f'
+const SALT = '0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf758dc33cc0'
+
 
 const CHAINID = 4444
 const ZEROADDR = '0x000000000000000000000000000000000000000000000'
@@ -24,7 +26,7 @@ contract('SimpleMultiSig', function(accounts) {
 
   let createSigs = function(signers, multisigAddr, nonce, destinationAddr, value, data, executor, gasLimit) {
 
-    const domainData = EIP712DOMAINTYPE_HASH + NAME_HASH.slice(2) + VERSION_HASH.slice(2) + CHAINID.toString('16').padStart(64, '0') + multisigAddr.slice(2).padStart(64, '0')
+    const domainData = EIP712DOMAINTYPE_HASH + NAME_HASH.slice(2) + VERSION_HASH.slice(2) + CHAINID.toString('16').padStart(64, '0') + multisigAddr.slice(2).padStart(64, '0') + SALT.slice(2)
     DOMAIN_SEPARATOR = web3.sha3(domainData, {encoding: 'hex'})
 
     let txInput = TXTYPE_HASH + destinationAddr.slice(2).padStart(64, '0') + value.toString('16').padStart(64, '0') + web3.sha3(data, {encoding: 'hex'}).slice(2) + nonce.toString('16').padStart(64, '0') + executor.slice(2).padStart(64, '0') + gasLimit.toString('16').padStart(64, '0')

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -11,11 +11,11 @@ let DOMAIN_SEPARATOR
 const TXTYPE_HASH = '0x3ee892349ae4bbe61dce18f95115b5dc02daf49204cc602458cd4c1f540d56d7'
 const NAME_HASH = '0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6'
 const VERSION_HASH = '0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6'
-const EIP712DOMAINTYPE_HASH = '0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f'
+const EIP712DOMAINTYPE_HASH = '0xd87cd6ef79d4e2b95e15ce8abf732db51ec771f1ca2edccf22a46c729ac56472'
 const SALT = '0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf758dc33cc0'
 
 
-const CHAINID = 4444
+const CHAINID = 1
 const ZEROADDR = '0x000000000000000000000000000000000000000000000'
 
 contract('SimpleMultiSig', function(accounts) {
@@ -46,6 +46,20 @@ contract('SimpleMultiSig', function(accounts) {
       sigS.push('0x' + sig.s.toString('hex'))
     }
 
+    // if (signers[0] == acct[0]) {
+    //   console.log("Signer: " + signers[0])
+    //   console.log("Wallet address: " + multisigAddr)
+    //   console.log("Destination: " + destinationAddr)
+    //   console.log("Value: " + value)
+    //   console.log("Data: " + data)
+    //   console.log("Nonce: " + nonce)
+    //   console.log("Executor: " + executor)
+    //   console.log("gasLimit: " + gasLimit)
+    //   console.log("r: " + sigR[0])
+    //   console.log("s: " + sigS[0])
+    //   console.log("v: " + sigV[0])
+    // }
+      
     return {sigV: sigV, sigR: sigR, sigS: sigS}
 
   }
@@ -233,6 +247,11 @@ contract('SimpleMultiSig', function(accounts) {
       executeSendFailure(acct.slice(0,3), 2, signers, 0, accounts[0], 100000, done)
     })
 
+    it("should fail with the wrong nonce", (done) => {
+      const nonceOffset = 1
+      executeSendFailure(acct.slice(0,3), 2, [acct[0], acct[1]], nonceOffset, accounts[0], 100000, done)
+    })
+    
   })  
 
   describe("Edge cases", () => {
@@ -255,7 +274,7 @@ contract('SimpleMultiSig', function(accounts) {
 
   describe("Hash constants", () => {
     it("uses correct hash for EIP712DOMAINTYPE", (done) => {
-      const eip712DomainType = 'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+      const eip712DomainType = 'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)'
       assert.equal(web3.sha3(eip712DomainType), EIP712DOMAINTYPE_HASH)
       done()
     })

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -2,7 +2,6 @@ var SimpleMultiSig = artifacts.require("./SimpleMultiSig.sol")
 var TestRegistry = artifacts.require("./TestRegistry.sol")
 var lightwallet = require('eth-lightwallet')
 const Promise = require('bluebird')
-const BigNumber = require('bignumber.js')
 
 const web3SendTransaction = Promise.promisify(web3.eth.sendTransaction)
 const web3GetBalance = Promise.promisify(web3.eth.getBalance)
@@ -72,7 +71,7 @@ contract('SimpleMultiSig', function(accounts) {
     let msgSender = accounts[0]
     
     // Receive funds
-    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(new BigNumber(0.1), 'ether')})
+    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(web3.toBigNumber(0.1), 'ether')})
 
     let nonce = await multisig.nonce.call()
     assert.equal(nonce.toNumber(), 0)
@@ -86,7 +85,7 @@ contract('SimpleMultiSig', function(accounts) {
       assert.equal(owners[i], ownerFromContract)
     }
 
-    let value = web3.toWei(new BigNumber(0.01), 'ether')
+    let value = web3.toWei(web3.toBigNumber(0.01), 'ether')
 
     let sigs = createSigs(signers, multisig.address, nonce, randomAddr, value, '', executor, 21000)
 
@@ -145,10 +144,10 @@ contract('SimpleMultiSig', function(accounts) {
     assert.equal(nonce.toNumber(), 0)
 
     // Receive funds
-    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(new BigNumber(2), 'ether')})
+    await web3SendTransaction({from: accounts[0], to: multisig.address, value: web3.toWei(web3.toBigNumber(2), 'ether')})
 
     let randomAddr = web3.sha3(Math.random().toString()).slice(0,42)
-    let value = web3.toWei(new BigNumber(0.1), 'ether')
+    let value = web3.toWei(web3.toBigNumber(0.1), 'ether')
     let sigs = createSigs(signers, multisig.address, nonce + nonceOffset, randomAddr, value, '', executor, gasLimit)
 
     let errMsg = ''
@@ -318,7 +317,7 @@ contract('SimpleMultiSig', function(accounts) {
 
       const walletAddress = '0xe3de7de481cbde9b4d5f62c6d228ec62277560c8'
       const destination = '0x8582afea2dd8e47297dbcdcf9ca289756ee21430'
-      const value = web3.toWei(new BigNumber(0.01), 'ether')
+      const value = web3.toWei(web3.toBigNumber(0.01), 'ether')
       const data = '0xf207564e0000000000000000000000000000000000000000000000000000000000003039'
       const nonce = 2
       const executor = '0x0be430662ec0659ee786c04925c0146991fbdc0f'

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -296,5 +296,45 @@ contract('SimpleMultiSig', function(accounts) {
     })
   })
 
+  describe("Browser MetaMask test", () => {
+    it("Matches the signature from MetaMask", (done) => {
+
+      // To test in MetaMask:
+      //
+      // Import the following private key in MetaMask:
+      // 0x022257944893befdd9089259c60346fe12b47621cb58670670dd21dc2fd15674c9
+      // It should give the address:
+      // 0x01BF9878a7099b2203838f3a8E7652Ad7B127A26
+      //
+      // Make sure you are on Mainnet with the above account
+      // Load the HTML page located at
+      // browsertest/index.html
+      // and click "Sign data" (using the default values).
+      // You should see the signature values r,s,v below:
+
+      const mmSigR = '0x91a622ccbd1c65debc16cfa1761b6200acc42099a19d753c7c59ceb12a8f5cfc'
+      const mmSigS = '0x6814fae69a6cc506b11adf971ca233fbcdbdca312ab96a58eb6b6b6792771fd4'
+      const mmSigV = 27
+
+      const walletAddress = '0xe3de7de481cbde9b4d5f62c6d228ec62277560c8'
+      const destination = '0x8582afea2dd8e47297dbcdcf9ca289756ee21430'
+      const value = web3.toWei(new BigNumber(0.01), 'ether')
+      const data = '0xf207564e0000000000000000000000000000000000000000000000000000000000003039'
+      const nonce = 2
+      const executor = '0x0be430662ec0659ee786c04925c0146991fbdc0f'
+      const gasLimit = 100000
+      const signers = [acct[0]]
+
+      let sigs = createSigs(signers, walletAddress, nonce, destination, value, data, executor, gasLimit)
+      
+      assert.equal(sigs.sigR[0], mmSigR)
+      assert.equal(sigs.sigS[0], mmSigS)
+      assert.equal(sigs.sigV[0], mmSigV)
+      
+      done()
+    })
+  })
+
+  
   
 })


### PR DESCRIPTION
Large update to support [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).

* Backwards incompatible update of main contract to support [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).

* Add `executor` to the signed data in order to specify which address needs to call the `execute` function. Allows `address(0)` as valid executor if the signers want anyone to be able \
to execute the transaction.

* Add `gasLimit` to the signed data in order to specify how much gas to supply to the function call.

* Change fallback function from `public` to `external`.

* Update tests for EIP712.

* Add test for wrong nonce.