### PR TITLE
Fix typos, fix browser test

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes #
 
+## Version 2.0.1 - 2019-06-19
+
+* Fix misspellings in contract comments. By [ethers](https://github.com/ethers).
+
+* Update browser test with check for web3 object.
+
+* Fix faulty documentation of private key in MetaMask browser test.
+
 ## Version 2.0.0 - 2018-08-18 ##
 
 * Backwards incompatible update of main contract to support [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).

--- a/browsertest/sign.js
+++ b/browsertest/sign.js
@@ -15,6 +15,7 @@ window.onload = function (e) {
   // force the user to unlock their MetaMask
   if (web3.eth.accounts[0] == null) {
     alert("Please unlock MetaMask first");
+    web3.currentProvider.enable().catch(alert);
   }
 
   var signBtn = document.getElementById("signBtn");

--- a/contracts/SimpleMultiSig.sol
+++ b/contracts/SimpleMultiSig.sol
@@ -6,13 +6,13 @@ contract SimpleMultiSig {
 // keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)")
 bytes32 constant EIP712DOMAINTYPE_HASH = 0xd87cd6ef79d4e2b95e15ce8abf732db51ec771f1ca2edccf22a46c729ac56472;
 
-// kekkac256("Simple MultiSig")
+// keccak256("Simple MultiSig")
 bytes32 constant NAME_HASH = 0xb7a0bfa1b79f2443f4d73ebb9259cddbcd510b18be6fc4da7d1aa7b1786e73e6;
 
-// kekkac256("1")
+// keccak256("1")
 bytes32 constant VERSION_HASH = 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6;
 
-// kekkac256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce,address executor,uint256 gasLimit)")
+// keccak256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce,address executor,uint256 gasLimit)")
 bytes32 constant TXTYPE_HASH = 0x3ee892349ae4bbe61dce18f95115b5dc02daf49204cc602458cd4c1f540d56d7;
 
 bytes32 constant SALT = 0x251543af6a222378665a76fe38dbceae4871a070b7fdaf5c6c30cf758dc33cc0;

--- a/test/simplemultisig.js
+++ b/test/simplemultisig.js
@@ -301,7 +301,7 @@ contract('SimpleMultiSig', function(accounts) {
       // To test in MetaMask:
       //
       // Import the following private key in MetaMask:
-      // 0x022257944893befdd9089259c60346fe12b47621cb58670670dd21dc2fd15674c9
+      // 0xac6d4b13220cd81f3630b7714f7e205494acc0823fb07a63bb40e65f669cbb9e
       // It should give the address:
       // 0x01BF9878a7099b2203838f3a8E7652Ad7B127A26
       //


### PR DESCRIPTION
Fixing typos (by ethers). Browser test was referring to the wrong key, fixed with correct private key.